### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,10 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   Palladio-Supporting-EMFProfilesEditor:
-    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.3
+    uses: PalladioSimulator/Palladio-Build-ActionsPipeline/.github/workflows/build.yml@v3.4
     with:
       use-display-output: true
       no-caching: true
-      runner-label: ubuntu-latest
       deploy-updatesite: 'releng/org.palladiosimulator.emfprofileseditor.updatesite/target/repository'
     secrets:
       SERVER_SSH_KEY: ${{ secrets.DEPLOYMENT_SERVER_SSH_KEY }}


### PR DESCRIPTION
This update is part of the new [dynamic build pipeline](https://github.com/PalladioSimulator/Palladio-Build-Nightly/tree/autogenerate) for nightly builds.

As discussed with @Nicolas-Boltz @larissaschmid 
- Updated to https://github.com/PalladioSimulator/Palladio-Build-ActionsPipeline/releases/tag/v3.4
- Removed runner label (if necessary)